### PR TITLE
Remove link to non-existing about page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,6 @@ gems: [jekyll-paginate]
 paginate_path: "/page:num"
 rss_path: /feed.xml
 navigation:
-- text: About
-  url: /about/
 - text: Projects
   url: /projects/
 - text: Resources


### PR DESCRIPTION
The page isn't there, and clicking in "About" produces a 404 link.